### PR TITLE
[Mellanox] Add 'hw-management-generate-dump.sh' to 'show techsupport' command

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -514,6 +514,7 @@ main() {
     # run 'hw-management-generate-dump.sh' script and save the result file
     /usr/bin/hw-management-generate-dump.sh    
     save_file "/tmp/hw-mgmt-dump*" "hw-mgmt" false
+    rm -f /tmp/hw-mgmt-dump*
 
     # clean up working tar dir before compressing
     $RM $V -rf $TARDIR

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -511,6 +511,10 @@ main() {
         fi
     done
 
+    # run 'hw-management-generate-dump.sh' script and save the result file
+    /usr/bin/hw-management-generate-dump.sh    
+    save_file "/tmp/hw-mgmt-dump*" "hw-mgmt" false
+
     # clean up working tar dir before compressing
     $RM $V -rf $TARDIR
 


### PR DESCRIPTION
**- What I did**
Added 'hw-management-generate-dump.sh' to 'generate_dump' script.
this addon will provide new information under the dump folder regarding hw-mgmt.
New information:

- SMBIOS info - version, system info, base board info
- FW info
- hw-management tree (the fs tree under /var/run/hw-management).
- system fs tree contains: block, bus, class, kernel, power etc..
- system interrupts.
- registers status.
- system sensors data.
- system log.
- Linux version and build.
- current processes,'top' output.

**- How to verify it**
run 'show techsupport' command and see the result file under
/var/dump/sonic_dump_'hostname'_'time'/hw-mgmt