### PR TITLE
[Mellanox] Enhance QSFP-DD DOM information

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -96,6 +96,19 @@ qsfp_dom_channel_monitor_map = {'rx1power': 'RX1Power', 'rx2power': 'RX2Power',
                                 'tx1power': 'TX1Power', 'tx2power': 'TX2Power',
                                 'tx3power': 'TX3Power', 'tx4power': 'TX4Power'}
 
+qsfp_dd_dom_channel_monitor_map = {'rx1power': 'RX1Power', 'rx2power': 'RX2Power',
+                                'rx3power': 'RX3Power', 'rx4power': 'RX4Power',
+                                'rx5power': 'RX5Power', 'rx6power': 'RX6Power',
+                                'rx7power': 'RX7Power', 'rx8power': 'RX8Power',
+                                'tx1bias':  'TX1Bias',  'tx2bias':  'TX2Bias',
+                                'tx3bias':  'TX3Bias',  'tx4bias':  'TX4Bias',
+                                'tx5bias':  'TX5Bias',  'tx6bias':  'TX6Bias',
+                                'tx7bias':  'TX7Bias',  'tx8bias':  'TX8Bias',
+                                'tx1power': 'TX1Power', 'tx2power': 'TX2Power',
+                                'tx3power': 'TX3Power', 'tx4power': 'TX4Power',
+                                'tx5power': 'TX5Power', 'tx6power': 'TX6Power',
+                                'tx7power': 'TX7Power', 'tx8power': 'TX8Power'}
+
 dom_module_monitor_map = {'temperature': 'Temperature', 'voltage': 'Vcc'}
 
 dom_channel_threshold_unit_map = {
@@ -130,6 +143,20 @@ dom_value_unit_map = {'rx1power': 'dBm', 'rx2power': 'dBm',
                       'tx3bias': 'mA', 'tx4bias': 'mA',
                       'tx1power': 'dBm', 'tx2power': 'dBm',
                       'tx3power': 'dBm', 'tx4power': 'dBm',
+                      'temperature': 'C', 'voltage': 'Volts'}
+
+qsfp_dd_dom_value_unit_map = {'rx1power': 'dBm', 'rx2power': 'dBm',
+                      'rx3power': 'dBm', 'rx4power': 'dBm',
+                      'rx5power': 'dBm', 'rx6power': 'dBm',
+                      'rx7power': 'dBm', 'rx8power': 'dBm',
+                      'tx1bias': 'mA', 'tx2bias': 'mA',
+                      'tx3bias': 'mA', 'tx4bias': 'mA',
+                      'tx5bias': 'mA', 'tx6bias': 'mA',
+                      'tx7bias': 'mA', 'tx8bias': 'mA',
+                      'tx1power': 'dBm', 'tx2power': 'dBm',
+                      'tx3power': 'dBm', 'tx4power': 'dBm',
+                      'tx5power': 'dBm', 'tx6power': 'dBm',
+                      'tx7power': 'dBm', 'tx8power': 'dBm',
                       'temperature': 'C', 'voltage': 'Volts'}
 
 def display_invalid_intf_eeprom(intf_name):
@@ -185,14 +212,24 @@ class SFPShow(object):
 
         if sfp_type.startswith('QSFP'):
             #Channel Monitor
-            out_put_dom = (out_put_dom + ident + 'ChannelMonitorValues'
-                                                             + newline_ident)
-            sorted_key_table = natsorted(qsfp_dom_channel_monitor_map)
-            out_put_channel = self.format_dict_value_to_string(
-                                            sorted_key_table, dom_info_dict,
-                                            qsfp_dom_channel_monitor_map,
-                                            dom_value_unit_map)
-            out_put_dom = out_put_dom + out_put_channel
+            if sfp_type.startswith('QSFP-DD'):
+                out_put_dom = (out_put_dom + ident + 'ChannelMonitorValues'
+                                                                + newline_ident)
+                sorted_key_table = natsorted(qsfp_dd_dom_channel_monitor_map)
+                out_put_channel = self.format_dict_value_to_string(
+                                                sorted_key_table, dom_info_dict,
+                                                qsfp_dd_dom_channel_monitor_map,
+                                                qsfp_dd_dom_value_unit_map)
+                out_put_dom = out_put_dom + out_put_channel
+            else:
+                out_put_dom = (out_put_dom + ident + 'ChannelMonitorValues'
+                                                                + newline_ident)
+                sorted_key_table = natsorted(qsfp_dom_channel_monitor_map)
+                out_put_channel = self.format_dict_value_to_string(
+                                                sorted_key_table, dom_info_dict,
+                                                qsfp_dom_channel_monitor_map,
+                                                dom_value_unit_map)
+                out_put_dom = out_put_dom + out_put_channel
 
             #Channel Threshold
             out_put_dom = (out_put_dom + ident + 'ChannelThresholdValues'


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
New driver support fetching additional pages from the cable EEPROM.
There are additional information to parse now: RX/TX power, TX bias, TX fault and RX LOS.

**- How I did it**
Add a QSFP-DD dictionaries to 'sfpshow' script and use it when a QSFP-DD cable is parsed (8 lanes).

**- How to verify it**
Connect a QSFP-DD active cable to the switch.
Run 'show interface transceiver eeprom Ethernet# -d' command.
Observe the "ChannelMonitorValues" output.

**- Previous command output (if the output of a command-line utility has changed)**

        Ethernet0: SFP EEPROM detected
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Active Cable assembly with BER < 2.6x10^-4
        			                     IB EDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 5x10^-5
        			                     IB QDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 10^-12
        				   
        Connector: No separable connector
        Encoding: Not supported for CMIS cables
        Extended Identifier: Power Class 1(10.0W Max)
        Extended RateSelect Compliance: Not supported for CMIS cables
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 10
        Nominal Bit Rate(100Mbs): Not supported for CMIS cables
        Specification compliance: Not supported for CMIS cables
        Vendor Date Code(YYYY-MM-DD Lot): 2020-05-22 
        Vendor Name: INNOLIGHT
        Vendor OUI: 44-7c-7f
        Vendor PN: C-DQ8FNM010-N00
        Vendor Rev: 2A
        Vendor SN: INKAO2900002A
        ChannelMonitorValues: 
        ChannelThresholdValues: 
                RxPowerHighAlarm  : 6.9999dBm
                RxPowerHighWarning: 4.9999dBm
                RxPowerLowAlarm   : -11.9044dBm
                RxPowerLowWarning : -8.9008dBm
                TxBiasHighAlarm   : 14.9960mA
                TxBiasHighWarning : 12.9980mA
                TxBiasLowAlarm    : 4.4960mA
                TxBiasLowWarning  : 5.0000mA
        ModuleMonitorValues: 
                Temperature: 44.9883C
                Vcc: 3.2999Volts
        ModuleThresholdValues: 
                TempHighAlarm  : 80.0000C
                TempHighWarning: 75.0000C
                TempLowAlarm   : -10.0000C
                TempLowWarning : -5.0000C
                VccHighAlarm   : 3.6352Volts
                VccHighWarning : 3.4672Volts
                VccLowAlarm    : 2.9696Volts
                VccLowWarning  : 3.1304Volts


**- New command output (if the output of a command-line utility has changed)**

        Ethernet0: SFP EEPROM detected
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Active Cable assembly with BER < 2.6x10^-4
        				             IB EDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 5x10^-5
        				             IB QDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 10^-12
        				   
        Connector: No separable connector
        Encoding: Not supported for CMIS cables
        Extended Identifier: Power Class 1(10.0W Max)
        Extended RateSelect Compliance: Not supported for CMIS cables
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 10
        Nominal Bit Rate(100Mbs): Not supported for CMIS cables
        Specification compliance: Not supported for CMIS cables
        Vendor Date Code(YYYY-MM-DD Lot): 2020-05-22 
        Vendor Name: INNOLIGHT
        Vendor OUI: 44-7c-7f
        Vendor PN: C-DQ8FNM010-N00
        Vendor Rev: 2A
        Vendor SN: INKAO2900002A
        ChannelMonitorValues: 
                RX1Power: -3.8595dBm
                RX2Power: 8.1478dBm
                RX3Power: -22.9243dBm
                RX4Power: 1.175dBm
                RX5Power: 1.2421dBm
                RX6Power: 8.1489dBm
                RX7Power: -3.5962dBm
                RX8Power: -3.6131dBm
                TX1Bias: 17.4760mA
                TX2Bias: 17.4760mA
                TX2Power: 1.175dBm
                TX3Bias: 0.0000mA
                TX3Power: 1.175dBm
                TX4Bias: 0.0000mA
                TX4Power: 8.1647dBm
                TX5Bias: 0.0000mAmA
                TX5Power: -3.5962dBm
                TX6Bias: 8.2240mAmA
                TX6Power: -3.5962dBm
                TX7Bias: 8.2240mAmA
                TX8Bias: 8.2240mAmA
        ChannelThresholdValues: 
                RxPowerHighAlarm  : 6.9999dBm
                RxPowerHighWarning: 4.9999dBm
                RxPowerLowAlarm   : -11.9044dBm
                RxPowerLowWarning : -8.9008dBm
                TxBiasHighAlarm   : 14.9960mA
                TxBiasHighWarning : 12.9980mA
                TxBiasLowAlarm    : 4.4960mA
                TxBiasLowWarning  : 5.0000mA
        ModuleMonitorValues: 
                Temperature: 44.9883C
                Vcc: 3.2999Volts
        ModuleThresholdValues: 
                TempHighAlarm  : 80.0000C
                TempHighWarning: 75.0000C
                TempLowAlarm   : -10.0000C
                TempLowWarning : -5.0000C
                VccHighAlarm   : 3.6352Volts
                VccHighWarning : 3.4672Volts
                VccLowAlarm    : 2.9696Volts
                VccLowWarning  : 3.1304Volts
