### PR TITLE
[show] Add support for NVMe SSD disc type on 'show platform ssdhealth'

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1047,7 +1047,12 @@ def psustatus(index, verbose):
 def ssdhealth(device, verbose, vendor):
     """Show SSD Health information"""
     if not device:
-        device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
+        device_list = os.popen("lsblk -o NAME,TYPE -p | grep disk").readlines()
+        for device_object in device_list:
+            if "nvme" in device_object:
+                device = device_object.strip().split()[0]
+        if not device:
+            device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
     cmd = "ssdutil -d " + device
     options = " -v" if verbose else ""
     options += " -e" if vendor else ""


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add a check if there is a NVMe disc installed on the system, if there is then use it as default disc.

**- How I did it**
Iterate all available discs and search for 'nvme' disc.

**- How to verify it**
Run 'show platform ssdhealth' on a system with NVMe disc installed.

**- Previous command output (if the output of a command-line utility has changed)**

root@sonic:/usr/sbin# show platform ssdhealth 
Device Model : N/A
Health       : N/A
Temperature  : N/A

**- New command output (if the output of a command-line utility has changed)**

root@sonic:/usr/sbin# show platform ssdhealth 
Device Model : KXG60ZNV256G TOSHIBA
Health       : 100.00%
Temperature  : 25C

