### PR TITLE
[PFCWD] Fix 'start' pfcwd command

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -167,6 +167,9 @@ class PfcwdCli(object):
         port_set = set(ports)
         # "all" is a valid option, remove before performing set diff
         port_set.discard("all")
+        # "detection-time" and "ports" are part of the arg tuple, remove before performing set diff
+        port_set.discard("detection-time")
+        port_set.discard("ports")
         return port_set - set(self.all_ports)
 
     @multi_asic_util.run_on_multi_asic


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
On checking invalid ports exclude "detection-time" and "ports" since it is part of the arg tuple.
These are handled later on the command processing.
This degradation caused by https://github.com/Azure/sonic-utilities/commit/b2261595de030df59698fd3a1095edb9b5796ee2

**- How I did it**
Discard these two values when checking invalid ports.

**- How to verify it**
Run "config pfcwd start --action drop ports all detection-time 400 --restoration-time 400"

**- Previous command output (if the output of a command-line utility has changed)**
config pfcwd start --action drop ports all detection-time 400 --restoration-time 400
Failed to run command, invalid options:
ports
detection-time

**- New command output (if the output of a command-line utility has changed)**
Command succeeded.
