### PR TITLE
[fast-reboot] Fix dump script to support PortChannels in a VLAN group

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -184,8 +184,8 @@ def generate_fdb_entries(filename):
 
     asic_db = swsssdk.SonicV2Connector(host='127.0.0.1')
     app_db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    asic_db.connect(db.ASIC_DB, False)   # Make one attempt only
-    app_db.connect(db.APPL_DB, False)   # Make one attempt only
+    asic_db.connect(asic_db.ASIC_DB, False)   # Make one attempt only
+    app_db.connect(app_db.APPL_DB, False)   # Make one attempt only
 
     bridge_id_2_iface = get_map_bridge_port_id_2_iface_name(asic_db, app_db)
 

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -80,13 +80,13 @@ def get_bridge_port_id_2_port_id(db):
 
     return bridge_port_id_2_port_id
 
-def get_lag_name(member_name, app_db):
-    keys = app_db.keys(app_db.APPL_DB, 'LAG_MEMBER_TABLE:PortChannel*')
+def get_lag_by_member(member_name, app_db):
+    keys = app_db.keys(app_db.APPL_DB, 'LAG_MEMBER_TABLE:*')
     keys = [] if keys is None else keys
     for key in keys:
-        entry = key.split(":")
-        if entry[2] == member_name:
-            return entry[1]
+        _, lag_name, lag_member_name = key.split(":")
+        if lag_member_name == member_name:
+            return lag_name
     return None
 
 def get_map_port_id_2_iface_name(asic_db, app_db):
@@ -110,7 +110,7 @@ def get_map_port_id_2_iface_name(asic_db, app_db):
             continue
         member_id = value['SAI_LAG_MEMBER_ATTR_PORT_ID']
         member_name = port_id_2_iface[member_id]
-        lag_name = get_lag_name(member_name, app_db)
+        lag_name = get_lag_by_member(member_name, app_db)
         if lag_name is not None:
             port_id_2_iface[lag_id] = lag_name
 

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -80,23 +80,45 @@ def get_bridge_port_id_2_port_id(db):
 
     return bridge_port_id_2_port_id
 
-def get_map_port_id_2_iface_name(db):
-    port_id_2_iface = {}
-    keys = db.keys(db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:*')
+def get_lag_name(member_name, app_db):
+    keys = app_db.keys(app_db.APPL_DB, 'LAG_MEMBER_TABLE:PortChannel*')
     keys = [] if keys is None else keys
     for key in keys:
-        value = db.get_all(db.ASIC_DB, key)
+        entry = key.split(":")
+        if entry[2] == member_name:
+            return entry[1]
+    return None
+
+def get_map_port_id_2_iface_name(asic_db, app_db):
+    port_id_2_iface = {}
+    keys = asic_db.keys(asic_db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:*')
+    keys = [] if keys is None else keys
+    for key in keys:
+        value = asic_db.get_all(asic_db.ASIC_DB, key)
         if value['SAI_HOSTIF_ATTR_TYPE'] != 'SAI_HOSTIF_TYPE_NETDEV':
             continue
         port_id = value['SAI_HOSTIF_ATTR_OBJ_ID']
         iface_name = value['SAI_HOSTIF_ATTR_NAME']
         port_id_2_iface[port_id] = iface_name
 
+    keys = asic_db.keys(asic_db.ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:*')
+    keys = [] if keys is None else keys
+    for key in keys:
+        value = asic_db.get_all(asic_db.ASIC_DB, key)
+        lag_id = value['SAI_LAG_MEMBER_ATTR_LAG_ID']
+        if lag_id in port_id_2_iface:
+            continue
+        member_id = value['SAI_LAG_MEMBER_ATTR_PORT_ID']
+        member_name = port_id_2_iface[member_id]
+        lag_name = get_lag_name(member_name, app_db)
+        if lag_name is not None:
+            port_id_2_iface[lag_id] = lag_name
+
     return port_id_2_iface
 
-def get_map_bridge_port_id_2_iface_name(db):
-    bridge_port_id_2_port_id = get_bridge_port_id_2_port_id(db)
-    port_id_2_iface = get_map_port_id_2_iface_name(db)
+def get_map_bridge_port_id_2_iface_name(asic_db, app_db):
+    bridge_port_id_2_port_id = get_bridge_port_id_2_port_id(asic_db)
+    port_id_2_iface = get_map_port_id_2_iface_name(asic_db, app_db)
 
     bridge_port_id_2_iface_name = {}
 
@@ -160,10 +182,12 @@ def get_fdb(db, vlan_name, vlan_id, bridge_id_2_iface):
 def generate_fdb_entries(filename):
     fdb_entries = []
 
-    db = swsssdk.SonicV2Connector(host='127.0.0.1')
-    db.connect(db.ASIC_DB, False)   # Make one attempt only
+    asic_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    app_db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    asic_db.connect(db.ASIC_DB, False)   # Make one attempt only
+    app_db.connect(db.APPL_DB, False)   # Make one attempt only
 
-    bridge_id_2_iface = get_map_bridge_port_id_2_iface_name(db)
+    bridge_id_2_iface = get_map_bridge_port_id_2_iface_name(asic_db, app_db)
 
     vlan_ifaces = get_vlan_ifaces()
 
@@ -171,11 +195,12 @@ def generate_fdb_entries(filename):
     map_mac_ip_per_vlan = {}
     for vlan in vlan_ifaces:
         vlan_id = int(vlan.replace('Vlan', ''))
-        fdb_entry, available_macs, map_mac_ip_per_vlan[vlan] = get_fdb(db, vlan, vlan_id, bridge_id_2_iface)
+        fdb_entry, available_macs, map_mac_ip_per_vlan[vlan] = get_fdb(asic_db, vlan, vlan_id, bridge_id_2_iface)
         all_available_macs |= available_macs
         fdb_entries.extend(fdb_entry)
 
-    db.close(db.ASIC_DB)
+    asic_db.close(asic_db.ASIC_DB)
+    app_db.close(app_db.APPL_DB)
 
     with open(filename, 'w') as fp:
         json.dump(fdb_entries, fp, indent=2, separators=(',', ': '))

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -39,7 +39,7 @@ def generate_neighbor_entries(filename, all_available_macs):
         }
         arp_output.append(obj)
 
-        ip_addr = key.split(':')[2]
+        ip_addr = key.split(':', 2)[2]
         if ipaddress.ip_interface(str(ip_addr)).ip.version != 4:
             #This is ipv6 address
             ip_addr = key.replace(key.split(':')[0] + ':' + key.split(':')[1] + ':', '')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add PortChannels to the list of interfaces (port_id_2_iface) to support FDB dump for PortChannel in a VLAN group.
Fixes issue https://github.com/Azure/sonic-buildimage/issues/4793

**- How I did it**
* Get LAG ID from the DB.
* Find the LAG name from APP DB.
* Add it to the list of 'port_id_2_iface' to be used.

**- How to verify it**
Reproduce the issue mentioned on this PR and try to run fast-reboot with this fix.

**- Previous command output (if the output of a command-line utility has changed)**
Traceback:
src_ifs = {map_mac_ip_per_vlan[vlan_name][dst_mac] for vlan_name, dst_mac, _ in arp_entries}
KeyError: 'b8:59:9f:a8:e2:00'

**- New command output (if the output of a command-line utility has changed)**
Success .
