### PR TITLE
Stop teamd docker to shutdown all LAGS on 'config reload'

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -725,6 +725,7 @@ def _stop_services(config_db):
     # This list is order-dependent. Please add services in the order they should be stopped
     # on Mellanox platform pmon is stopped by syncd
     services_to_stop = [
+        'teamd',
         'telemetry',
         'restapi',
         'swss',


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add 'teamd' to the list of stop services when running 'config reload' command.

**- How I did it**

**- How to verify it**
Run 'config reload' command.

**- Previous command output (if the output of a command-line utility has changed)**
The operation failed when a large number of PortChannel configured on the system.
Unloading the LAG's on the driver take a lot of time.
This will make the driver unload all netdev fast and the operation will execute properly

**- New command output (if the output of a command-line utility has changed)**
Success.
