### PR TITLE
[DHCP] Add DHCP relay CLI support for IPv6

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -206,13 +206,18 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
-    dhcp_relay_dests = vlan.get('dhcp_servers', [])
+    if clicommon.ipaddress_type(dhcp_relay_destination_ip) == 4:
+        dhcp_servers = 'dhcp_servers'
+    else:
+        dhcp_servers = 'dhcpv6_servers'
+
+    dhcp_relay_dests = vlan.get(dhcp_servers, [])
     if dhcp_relay_destination_ip in dhcp_relay_dests:
         click.echo("{} is already a DHCP relay destination for {}".format(dhcp_relay_destination_ip, vlan_name))
         return
 
     dhcp_relay_dests.append(dhcp_relay_destination_ip)
-    vlan['dhcp_servers'] = dhcp_relay_dests
+    vlan[dhcp_servers] = dhcp_relay_dests
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Added DHCP relay destination address {} to {}".format(dhcp_relay_destination_ip, vlan_name))
     try:
@@ -240,15 +245,20 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
-    dhcp_relay_dests = vlan.get('dhcp_servers', [])
+    if clicommon.ipaddress_type(dhcp_relay_destination_ip) == 4:
+        dhcp_servers = 'dhcp_servers'
+    else:
+        dhcp_servers = 'dhcpv6_servers'
+
+    dhcp_relay_dests = vlan.get(dhcp_servers, [])
     if not dhcp_relay_destination_ip in dhcp_relay_dests:
         ctx.fail("{} is not a DHCP relay destination for {}".format(dhcp_relay_destination_ip, vlan_name))
 
     dhcp_relay_dests.remove(dhcp_relay_destination_ip)
     if len(dhcp_relay_dests) == 0:
-        del vlan['dhcp_servers']
+        del vlan[dhcp_servers]
     else:
-        vlan['dhcp_servers'] = dhcp_relay_dests
+        vlan[dhcp_servers] = dhcp_relay_dests
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination address {} from {}".format(dhcp_relay_destination_ip, vlan_name))
     try:

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -197,45 +197,31 @@ def vlan_dhcp_relay():
 def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     """ Add a destination IP address to the VLAN's DHCP relay """
     ctx = click.get_current_context()
+    added_servers = []
 
-    dhcp_servers = []
-    dhcpv6_servers = []
-
-    # verify vlan is valid
+    # Verify vlan is valid
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.cfgdb.get_entry('VLAN', vlan_name)
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
-    # verify all ip addresses are valid
+    # Verify all ip addresses are valid and not exist in DB
+    dhcp_servers = vlan.get('dhcp_servers', [])
+    dhcpv6_servers = vlan.get('dhcpv6_servers', [])
+
     for ip_addr in dhcp_relay_destination_ips:
         try:
             ipaddress.ip_address(ip_addr)
+            if (ip_addr in dhcp_servers) or (ip_addr in dhcpv6_servers):
+                    click.echo("{} is already a DHCP relay destination for {}".format(ip_addr, vlan_name))
+                    continue
             if clicommon.ipaddress_type(ip_addr) == 4:
                 dhcp_servers.append(ip_addr)
             else:
                 dhcpv6_servers.append(ip_addr)
+            added_servers.append(ip_addr)
         except:
             ctx.fail('{} is invalid IP address'.format(ip_addr))
-
-    # verify ip addresses are not exist in DB
-    if len(dhcp_servers):
-        exist_dhcp_servers = vlan.get('dhcp_servers', [])
-        for dhcp_server in exist_dhcp_servers:
-            if dhcp_server in dhcp_servers:
-                click.echo("{} is already a DHCP relay destination for {}".format(dhcp_server, vlan_name))
-                return
-            else:
-                dhcp_servers.append(dhcp_server)
-
-    if len(dhcpv6_servers):
-        exist_dhcpv6_servers = vlan.get('dhcpv6_servers', [])
-        for dhcpv6_server in exist_dhcpv6_servers:
-            if dhcpv6_server in dhcpv6_servers:
-                click.echo("{} is already a DHCP relay destination for {}".format(dhcpv6_server, vlan_name))
-                return
-            else:
-                dhcpv6_servers.append(dhcpv6_server)
 
     # Append new dhcp servers to config DB
     if len(dhcp_servers):
@@ -245,14 +231,15 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
 
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
 
-    click.echo("Added DHCP relay destination addresses {} to {}".format(dhcp_relay_destination_ips, vlan_name))
-    try:
-        click.echo("Restarting DHCP relay service...")
-        clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
-        clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
-        clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
-    except SystemExit as e:
-        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+    if len(added_servers):
+        click.echo("Added DHCP relay destination addresses {} to {}".format(added_servers, vlan_name))
+        try:
+            click.echo("Restarting DHCP relay service...")
+            clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
+            clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
+            clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
+        except SystemExit as e:
+            ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
 @vlan_dhcp_relay.command('del')
 @click.argument('vid', metavar='<vid>', required=True, type=int)
@@ -260,57 +247,37 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
 @clicommon.pass_db
 def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     """ Remove a destination IP address from the VLAN's DHCP relay """
-
     ctx = click.get_current_context()
 
-    dhcp_servers = []
-    dhcpv6_servers = []
-
-    # verify vlan is valid
+    # Verify vlan is valid
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.cfgdb.get_entry('VLAN', vlan_name)
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
-    # verify all ip addresses are valid
+    # Remove dhcp servers if they exist in the DB
+    dhcp_servers = vlan.get('dhcp_servers', [])
+    dhcpv6_servers = vlan.get('dhcpv6_servers', [])
+
     for ip_addr in dhcp_relay_destination_ips:
-        try:
-            ipaddress.ip_address(ip_addr)
-            if clicommon.ipaddress_type(ip_addr) == 4:
-                dhcp_servers.append(ip_addr)
-            else:
-                dhcpv6_servers.append(ip_addr)
-        except:
-            ctx.fail('{} is invalid IP address'.format(ip_addr))
-
-    # remove DHCP servers
-    exist_dhcp_servers = vlan.get('dhcp_servers', [])
-    if len(dhcp_servers):
-        for dhcp_server in dhcp_servers:
-            if dhcp_server not in exist_dhcp_servers:
-                ctx.fail("{} is not a DHCP relay destination for {}".format(dhcp_server, vlan_name))
-            else:
-                exist_dhcp_servers.remove(dhcp_server)
-
-    exist_dhcpv6_servers = vlan.get('dhcpv6_servers', [])
-    if len(dhcpv6_servers):
-        for dhcpv6_server in dhcpv6_servers:
-            if dhcpv6_server not in exist_dhcpv6_servers:
-                ctx.fail("{} is not a DHCP relay destination for {}".format(dhcpv6_server, vlan_name))
-            else:
-                exist_dhcpv6_servers.remove(dhcpv6_server)
+        if (ip_addr not in dhcp_servers) and (ip_addr not in dhcpv6_servers):
+                ctx.fail("{} is not a DHCP relay destination for {}".format(ip_addr, vlan_name))
+        if clicommon.ipaddress_type(ip_addr) == 4:
+            dhcp_servers.remove(ip_addr)   
+        else:
+            dhcpv6_servers.remove(ip_addr)
 
     # Update dhcp servers to config DB
-    if len(exist_dhcp_servers):
-        vlan['dhcp_servers'] = exist_dhcp_servers
+    if len(dhcp_servers):
+        vlan['dhcp_servers'] = dhcp_servers
     else:
-        if len(dhcp_servers):
+        if 'dhcp_servers' in vlan.keys():
             del vlan['dhcp_servers']
 
-    if len(exist_dhcpv6_servers):
-        vlan['dhcpv6_servers'] = exist_dhcpv6_servers
+    if len(dhcpv6_servers):
+        vlan['dhcpv6_servers'] = dhcpv6_servers
     else:
-        if len(dhcpv6_servers):
+        if 'dhcpv6_servers' in vlan.keys():
             del vlan['dhcpv6_servers']
 
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2197,33 +2197,43 @@ This sub-section of commands is used to add or remove the DHCP Relay Destination
 
 **config vlan dhcp_relay add**
 
-This command is used to add a DHCP Relay Destination IP address to the a VLAN.  Note that more that one DHCP Relay Destination IP address can be added on a VLAN interface.
+This command is used to add a DHCP Relay Destination IP address or multiple IP addresses to a VLAN.  Note that more than one DHCP Relay Destination IP address can be added on a VLAN interface.
 
 - Usage:
   ```
-  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ip>
+  config vlan dhcp_relay add <vlan_id> <dhcp_relay_destination_ips>
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7
-  Added DHCP relay destination address 7.7.7.7 to Vlan1000
+  Added DHCP relay destination address ['7.7.7.7'] to Vlan1000
+  Restarting DHCP relay service...
+  ```
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay add 1000 7.7.7.7 1.1.1.1
+  Added DHCP relay destination address ['7.7.7.7', '1.1.1.1'] to Vlan1000
   Restarting DHCP relay service...
   ```
 
 **config vlan dhcp_relay delete**
 
-This command is used to delete a configured DHCP Relay Destination IP address from a VLAN interface.
+This command is used to delete a configured DHCP Relay Destination IP address or multiple IP addresses from a VLAN interface.
 
 - Usage:
   ```
-  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ip>
+  config vlan dhcp_relay del <vlan-id> <dhcp_relay_destination_ips>
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7
   Removed DHCP relay destination address 7.7.7.7 from Vlan1000
+  Restarting DHCP relay service...
+  ```
+  ```
+  admin@sonic:~$ sudo config vlan dhcp_relay del 1000 7.7.7.7 1.1.1.1
+  Removed DHCP relay destination address ('7.7.7.7', '1.1.1.1') from Vlan1000
   Restarting DHCP relay service...
   ```
 

--- a/show/vlan.py
+++ b/show/vlan.py
@@ -32,11 +32,15 @@ def brief(db, verbose):
 
     # Parsing DHCP Helpers info
     for key in natsorted(list(vlan_dhcp_helper_data.keys())):
-        try:
-            if vlan_dhcp_helper_data[key]['dhcp_servers']:
-                vlan_dhcp_helper_dict[key.strip('Vlan')] = vlan_dhcp_helper_data[key]['dhcp_servers']
-        except KeyError:
-            vlan_dhcp_helper_dict[key.strip('Vlan')] = " "
+        vlan_dhcp_helper_dict[key.strip('Vlan')] = []
+
+        dhcp_servers = vlan_dhcp_helper_data[key]['dhcp_servers'] if 'dhcp_servers' in vlan_dhcp_helper_data[key].keys() else []
+        if dhcp_servers:
+            vlan_dhcp_helper_dict[key.strip('Vlan')] += dhcp_servers
+
+        dhcpv6_servers = vlan_dhcp_helper_data[key]['dhcpv6_servers'] if 'dhcpv6_servers' in vlan_dhcp_helper_data[key].keys() else []
+        if dhcpv6_servers:
+            vlan_dhcp_helper_dict[key.strip('Vlan')] += dhcpv6_servers
 
     # Parsing VLAN Gateway info
     for key in vlan_ip_data:

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -111,22 +111,22 @@ Vlan4000   4000  PortChannel1001  tagged
 """
 
 config_vlan_add_dhcp_relay_output="""\
-Added DHCP relay destination address 192.0.0.100 to Vlan1000
+Added DHCP relay destination addresses ('192.0.0.100',) to Vlan1000
 Restarting DHCP relay service...
 """
 
 config_vlan_del_dhcp_relay_output="""\
-Removed DHCP relay destination address 192.0.0.100 from Vlan1000
+Removed DHCP relay destination addresses ('192.0.0.100',) from Vlan1000
 Restarting DHCP relay service...
 """
 
 config_vlan_add_dhcpv6_relay_output="""\
-Added DHCP relay destination address fc02:2000::1 to Vlan1000
+Added DHCP relay destination addresses ('fc02:2000::1',) to Vlan1000
 Restarting DHCP relay service...
 """
 
 config_vlan_del_dhcpv6_relay_output="""\
-Removed DHCP relay destination address fc02:2000::1 from Vlan1000
+Removed DHCP relay destination addresses ('fc02:2000::1',) from Vlan1000
 Restarting DHCP relay service...
 """
 
@@ -134,11 +134,11 @@ show_vlan_brief_output_with_new_dhcp_relay_address="""\
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |   VLAN ID | IP Address      | Ports           | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
 +===========+=================+=================+================+=======================+=============+
-|      1000 | 192.168.0.1/21  | Ethernet4       | untagged       | 192.0.0.1             | disabled    |
-|           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |             |
-|           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
-|           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
-|           |                 |                 |                | 192.0.0.100           |             |
+|      1000 | 192.168.0.1/21  | Ethernet4       | untagged       | 192.0.0.100           | disabled    |
+|           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.1             |             |
+|           |                 | Ethernet12      | untagged       | 192.0.0.2             |             |
+|           |                 | Ethernet16      | untagged       | 192.0.0.3             |             |
+|           |                 |                 |                | 192.0.0.4             |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             | enabled     |
 |           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |             |

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -6,6 +6,7 @@ import sys
 
 import click
 import json
+import netaddr
 
 from natsort import natsorted
 from sonic_py_common import multi_asic
@@ -199,6 +200,17 @@ def is_ipaddress(val):
         return False
     return True
 
+def ipaddress_type(val):
+    """ Return the IP address type """
+    if not val:
+        return None
+
+    try:
+        ip_version = netaddr.IPAddress(str(val))
+    except netaddr.core.AddrFormatError:
+        return None
+
+    return ip_version.version
 
 def is_ip_prefix_in_key(key):
     '''


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Adapt config/show CLI commands to support DHCPv6 relay feature.
Add a new function to 'cli common' to check the type of IP address.

#### How I did it
Edit 'vlan' config/show scripts to support 'dhcpv6_servers' along to the 'dhcp_servers'.

#### How to verify it
Build an image with this PR: https://github.com/shlomibitton/sonic-buildimage/pull/49
Use the CLI to add/remove DHCP servers with IPv6.

#### Previous command output (if the output of a command-line utility has changed)
-

#### New command output (if the output of a command-line utility has changed)
-
