### PR TITLE
[Fast-reboot] Set flex counters delay indicator to prevent flex counters enablement after fast-reboot

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -283,11 +283,17 @@ def _update_config_db(status, filename):
 
     write_config_db = False
     if "FLEX_COUNTER_TABLE" in config_db:
-        for counter, counter_config in config_db["FLEX_COUNTER_TABLE"].items():
-            if "FLEX_COUNTER_STATUS" in counter_config and \
-                counter_config["FLEX_COUNTER_STATUS"] is not status:
-                counter_config["FLEX_COUNTER_STATUS"] = status
-                write_config_db = True
+        if status != "delay":
+            for counter, counter_config in config_db["FLEX_COUNTER_TABLE"].items():
+                if "FLEX_COUNTER_STATUS" in counter_config and \
+                    counter_config["FLEX_COUNTER_STATUS"] is not status:
+                    counter_config["FLEX_COUNTER_STATUS"] = status
+                    write_config_db = True
+
+        elif status == "delay":
+            write_config_db = True
+            for key in config_db["FLEX_COUNTER_TABLE"].keys():
+                config_db["FLEX_COUNTER_TABLE"][key].update({"FLEX_COUNTER_DELAY_STATUS":"true"})
 
     if write_config_db:
         with open(filename, 'w') as config_db_file:
@@ -310,3 +316,8 @@ def disable(filename):
     """ Disable counter configuration in config_db file """
     _update_config_db("disable", filename)
 
+@config_db.command()
+@click.argument("filename", default="/etc/sonic/config_db.json", type=click.Path(exists=True))
+def delay(filename):
+    """ Delay counters in config_db file """
+    _update_config_db("delay", filename)

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -36,6 +36,7 @@ EXIT_ORCHAGENT_SHUTDOWN=10
 EXIT_SYNCD_SHUTDOWN=11
 EXIT_FAST_REBOOT_DUMP_FAILURE=12
 EXIT_FILTER_FDB_ENTRIES_FAILURE=13
+EXIT_COUNTERPOLL_DELAY_FAILURE=14
 EXIT_NO_CONTROL_PLANE_ASSISTANT=20
 EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
 
@@ -668,6 +669,18 @@ if [[ "$sonic_asic_type" = 'broadcom' ]];
 then
   service_name=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep opennsl | cut -f 1 -d' ')
   systemctl stop "$service_name"
+fi
+
+if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
+    CONFIG_DB_FILE=/etc/sonic/config_db.json
+    COUNTERPOLL_DELAY_RC=0
+    # Delay counters in config_db.json
+    /usr/local/bin/counterpoll config-db delay $CONFIG_DB_FILE || COUNTERPOLL_DELAY_RC=$?
+    if [[ COUNTERPOLL_DELAY_RC -ne 0 ]]; then
+        error "Failed to delay counterpoll. Exit code: $COUNTERPOLL_DELAY_RC"
+        unload_kernel
+        exit "${EXIT_COUNTERPOLL_DELAY_FAILURE}"
+    fi
 fi
 
 # Update the reboot cause file to reflect that user issued this script

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -319,6 +319,14 @@ def generate_default_route_entries(filename):
     with open(filename, 'w') as fp:
         json.dump(default_routes_output, fp, indent=2, separators=(',', ': '))
 
+def flex_counters_delay_indicator(filename):
+    with open(filename) as config_db_file:
+        config_db = json.load(config_db_file)
+        if "FLEX_COUNTER_TABLE" in config_db:
+            config_db["FLEX_COUNTER_TABLE"]["FLEX_COUNTER_DELAY"] = {"FLEX_COUNTER_DELAY_STATUS": "true"}
+
+            with open(filename, 'w') as config_db_file:
+                json.dump(config_db, config_db_file, indent=4)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -332,6 +340,7 @@ def main():
     neighbor_entries = generate_neighbor_entries(root_dir + '/arp.json', all_available_macs)
     generate_default_route_entries(root_dir + '/default_routes.json')
     send_garp_nd(neighbor_entries, map_mac_ip_per_vlan)
+    flex_counters_delay_indicator('/etc/sonic/config_db.json')
     return 0
 
 if __name__ == '__main__':

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -323,7 +323,8 @@ def set_flex_counters_delay_indicator(filename):
     with open(filename) as config_db_file:
         config_db = json.load(config_db_file)
         if "FLEX_COUNTER_TABLE" in config_db:
-            config_db["FLEX_COUNTER_TABLE"]["FLEX_COUNTER_DELAY"] = {"FLEX_COUNTER_DELAY_STATUS": "true"}
+            for key in config_db["FLEX_COUNTER_TABLE"].keys():
+                config_db["FLEX_COUNTER_TABLE"][key].update({"FLEX_COUNTER_DELAY_STATUS":"true"})
 
             with open(filename, 'w') as config_db_file:
                 json.dump(config_db, config_db_file, indent=4)

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -319,15 +319,6 @@ def generate_default_route_entries(filename):
     with open(filename, 'w') as fp:
         json.dump(default_routes_output, fp, indent=2, separators=(',', ': '))
 
-def set_flex_counters_delay_indicator(filename):
-    with open(filename) as config_db_file:
-        config_db = json.load(config_db_file)
-        if "FLEX_COUNTER_TABLE" in config_db:
-            for key in config_db["FLEX_COUNTER_TABLE"].keys():
-                config_db["FLEX_COUNTER_TABLE"][key].update({"FLEX_COUNTER_DELAY_STATUS":"true"})
-
-            with open(filename, 'w') as config_db_file:
-                json.dump(config_db, config_db_file, indent=4)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -341,7 +332,6 @@ def main():
     neighbor_entries = generate_neighbor_entries(root_dir + '/arp.json', all_available_macs)
     generate_default_route_entries(root_dir + '/default_routes.json')
     send_garp_nd(neighbor_entries, map_mac_ip_per_vlan)
-    set_flex_counters_delay_indicator('/etc/sonic/config_db.json')
     return 0
 
 if __name__ == '__main__':

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -319,7 +319,7 @@ def generate_default_route_entries(filename):
     with open(filename, 'w') as fp:
         json.dump(default_routes_output, fp, indent=2, separators=(',', ': '))
 
-def flex_counters_delay_indicator(filename):
+def set_flex_counters_delay_indicator(filename):
     with open(filename) as config_db_file:
         config_db = json.load(config_db_file)
         if "FLEX_COUNTER_TABLE" in config_db:
@@ -340,7 +340,7 @@ def main():
     neighbor_entries = generate_neighbor_entries(root_dir + '/arp.json', all_available_macs)
     generate_default_route_entries(root_dir + '/default_routes.json')
     send_garp_nd(neighbor_entries, map_mac_ip_per_vlan)
-    flex_counters_delay_indicator('/etc/sonic/config_db.json')
+    set_flex_counters_delay_indicator('/etc/sonic/config_db.json')
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Set flex counters delay indicator to prevent flex counters enablement after fast-reboot.

#### How I did it
Modify config DB json file with 'true' status for delay of flex counters indicator.

#### How to verify it
Run fast-reboot and observe counters are created only when enable_counters script is called, even if the tables are present in config DB.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

