### PR TITLE
Fix watermarkstat CLI script for unconfigured PG counters

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -209,7 +209,7 @@ class Watermarkstat(object):
         self.header_list = ['Port']
         header_map = wm_type["obj_map"]
 
-		self.min_idx = 0
+        self.min_idx = 0
         max_idx = 0
         for port in header_map.keys():
             for element in header_map[port].keys():

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -208,16 +208,16 @@ class Watermarkstat(object):
 
         self.header_list = ['Port']
         header_map = wm_type["obj_map"]
-        single_key = list(header_map.keys())[0]
-        header_len = len(header_map[single_key])
-        min_idx = sys.maxsize
+	self.min_idx = 0
+        max_idx = 0
+	
+        for port in header_map.keys():
+            for element in header_map[port].keys():
+                element_idx = int(element.split(':')[1])
+                if (element_idx > max_idx):
+                    max_idx = element_idx
 
-        for name, counter_oid in header_map[single_key].items():
-            curr_idx = int(wm_type["idx_func"](counter_oid))
-            min_idx = min(min_idx, curr_idx)
-
-        self.min_idx = min_idx
-        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, self.min_idx + header_len)]
+        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx)]
 
     def get_counters(self, table_prefix, port_obj, idx_func, watermark):
         """

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -208,16 +208,16 @@ class Watermarkstat(object):
 
         self.header_list = ['Port']
         header_map = wm_type["obj_map"]
-	self.min_idx = 0
+
+		self.min_idx = 0
         max_idx = 0
-	
         for port in header_map.keys():
             for element in header_map[port].keys():
                 element_idx = int(element.split(':')[1])
                 if (element_idx > max_idx):
                     max_idx = element_idx
 
-        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx)]
+        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx + 1)]
 
     def get_counters(self, table_prefix, port_obj, idx_func, watermark):
         """

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -209,6 +209,7 @@ class Watermarkstat(object):
         self.header_list = ['Port']
         header_map = wm_type["obj_map"]
 
+        min_idx_found = False
         self.min_idx = 0
         max_idx = 0
         for port in header_map.keys():
@@ -216,6 +217,11 @@ class Watermarkstat(object):
                 element_idx = int(element.split(':')[1])
                 if (element_idx > max_idx):
                     max_idx = element_idx
+                if (not min_idx_found):
+                    self.min_idx = element_idx
+                    min_idx_found = True
+                if (self.min_idx > element_idx):
+                    self.min_idx = element_idx
 
         self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx + 1)]
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Since PG counters are created only if they are configured in the switch, it is not enough to relay only on the first entry in the DB when building the output table of watermarkstat script.
We need to go over all configured counters, check what is the max configured, and build the table accordingly.

#### How I did it

Iterate all configured PG buffers for all ports and find the max index.
Build the output table according to the max index.

#### How to verify it

Run test "iface_namingmode/test_iface_namingmode.py" including this PR: https://github.com/Azure/sonic-swss/pull/2143 and observe it passes.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

